### PR TITLE
bundle:exec now sets System.getProperties() as ENV for JRuby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ bundler-maven-plugin.iml
 bundler-maven-plugin.ipr
 bundler-maven-plugin.iws
 target/
+
+.classpath
+.settings/
+.factorypath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.byclosure.maven.plugins</groupId>
 	<artifactId>bundler-maven-plugin</artifactId>
-	<version>0.0.3</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.byclosure.maven.plugins</groupId>
 	<artifactId>bundler-maven-plugin</artifactId>
-	<version>0.0.3-SNAPSHOT</version>
+	<version>0.0.3</version>
 	<packaging>maven-plugin</packaging>
 
 	<name>${project.groupId}:${project.artifactId}</name>
@@ -14,6 +14,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<javaVersion>1.7</javaVersion>
 	</properties>
 
 	<dependencies>
@@ -83,6 +84,31 @@
 						<goals>
 							<goal>helpmojo</goal>
 						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.2</version>
+				<configuration>
+					<source>${javaVersion}</source>
+					<target>${javaVersion}</target>
+					<compilerArgument>-proc:none</compilerArgument>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.bsc.maven</groupId>
+				<artifactId>maven-processor-plugin</artifactId>
+				<version>2.2.4</version>
+				<executions>
+					<execution>
+						<id>process</id>
+						<goals>
+							<goal>process</goal>
+						</goals>
+						<phase>generate-sources</phase>
 					</execution>
 				</executions>
 			</plugin>
@@ -167,7 +193,8 @@
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>

--- a/src/main/java/com/byclosure/maven/plugins/middleman/BundleExecMojo.java
+++ b/src/main/java/com/byclosure/maven/plugins/middleman/BundleExecMojo.java
@@ -1,18 +1,16 @@
 package com.byclosure.maven.plugins.middleman;
 
-import org.apache.commons.exec.CommandLine;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.exec.CommandLine;
 
 /**
  * @goal exec
  * @requiresProject true
  */
 public class BundleExecMojo extends AbstractJRubyMojo {
-
 	/**
 	 * @parameter default-value="" expression="${bundler.exec_args}"
 	 */
@@ -26,7 +24,8 @@ public class BundleExecMojo extends AbstractJRubyMojo {
 
 		final CommandLine cmd = getCrossPlatformCommandLine(jrubyFile.getPath());
 		cmd.addArgument("-S");
-		cmd.addArgument(new File(gem_home, new File("bin", "bundle").getPath()).getPath());
+		cmd.addArgument(new File(gem_home, new File("bin", "bundle").getPath())
+				.getPath());
 		cmd.addArgument("exec");
 
 		if (execArgs != null) {

--- a/src/main/java/com/byclosure/maven/plugins/middleman/BundleInstallMojo.java
+++ b/src/main/java/com/byclosure/maven/plugins/middleman/BundleInstallMojo.java
@@ -1,18 +1,16 @@
 package com.byclosure.maven.plugins.middleman;
 
-import org.apache.commons.exec.CommandLine;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.exec.CommandLine;
 
 /**
  * @goal install
  * @requiresProject true
  */
 public class BundleInstallMojo extends AbstractJRubyMojo {
-
 	/**
 	 * @parameter default-value="Gemfile" expression="${bundler.gemfile}"
 	 */
@@ -26,7 +24,8 @@ public class BundleInstallMojo extends AbstractJRubyMojo {
 
 		final CommandLine cmd = getCrossPlatformCommandLine(jrubyFile.getPath());
 		cmd.addArgument("-S");
-		cmd.addArgument(new File(gem_home, new File("bin", "bundle").getPath()).getPath());
+		cmd.addArgument(new File(gem_home, new File("bin", "bundle").getPath())
+				.getPath());
 		cmd.addArgument("install");
 		cmd.addArgument("--binstubs=" + binstubs);
 		cmd.addArgument("--shebang=jruby");

--- a/src/main/java/com/byclosure/maven/plugins/middleman/BundleUpdateMojo.java
+++ b/src/main/java/com/byclosure/maven/plugins/middleman/BundleUpdateMojo.java
@@ -1,18 +1,16 @@
 package com.byclosure.maven.plugins.middleman;
 
-import org.apache.commons.exec.CommandLine;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.exec.CommandLine;
 
 /**
  * @goal update
  * @requiresProject false
  */
 public class BundleUpdateMojo extends AbstractJRubyMojo {
-
 	/**
 	 * @parameter default-value="Gemfile" expression="${bundler.gemfile}"
 	 */
@@ -22,11 +20,12 @@ public class BundleUpdateMojo extends AbstractJRubyMojo {
 	protected void executeComand() throws IOException {
 		final File jrubyFile = new File(jruby_bin, "jruby");
 
-		final Map<String, String> env =  getEnv();
+		final Map<String, String> env = getEnv();
 
 		final CommandLine cmd = getCrossPlatformCommandLine(jrubyFile.getPath());
 		cmd.addArgument("-S");
-		cmd.addArgument(new File(gem_home, new File("bin", "bundle").getPath()).getPath());
+		cmd.addArgument(new File(gem_home, new File("bin", "bundle").getPath())
+				.getPath());
 		cmd.addArgument("update");
 
 		executeCommandLine(cmd, env, new File(working_dir));

--- a/src/main/java/com/byclosure/maven/plugins/middleman/Decompressor.java
+++ b/src/main/java/com/byclosure/maven/plugins/middleman/Decompressor.java
@@ -1,22 +1,26 @@
 package com.byclosure.maven.plugins.middleman;
 
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.io.IOUtils;
-
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
 public class Decompressor {
 	final static int BUFFER = 2048;
 
-	public static void decompress(String sourceFile, String destinationDir) throws IOException {
+	public static void decompress(String sourceFile, String destinationDir)
+			throws IOException {
 		/** create a TarArchiveInputStream object. **/
 		FileInputStream fin = new FileInputStream(sourceFile);
 		BufferedInputStream in = new BufferedInputStream(fin);
@@ -68,15 +72,19 @@ public class Decompressor {
 		System.out.println("untar completed successfully!!");
 	}
 
-	private static void applyPermissions(int mode, File file) throws IOException {
+	private static void applyPermissions(int mode, File file)
+			throws IOException {
 		final Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
 
 		String octal = Integer.toOctalString(mode);
-		octal = octal.substring(octal.length() -3);
+		octal = octal.substring(octal.length() - 3);
 
-		String binary = Integer.toBinaryString(Integer.parseInt(octal.substring(0, 1)));
-		binary += Integer.toBinaryString(Integer.parseInt(octal.substring(1, 2)));
-		binary += Integer.toBinaryString(Integer.parseInt(octal.substring(2, 3)));
+		String binary = Integer.toBinaryString(Integer.parseInt(octal
+				.substring(0, 1)));
+		binary += Integer
+				.toBinaryString(Integer.parseInt(octal.substring(1, 2)));
+		binary += Integer
+				.toBinaryString(Integer.parseInt(octal.substring(2, 3)));
 
 		if (binary.charAt(0) == '1') {
 			perms.add(PosixFilePermission.OWNER_READ);


### PR DESCRIPTION
The goal bundle:exec doesn't pass 'System.getProperties()' to JRuby. So when using the plugin 'properties-maven-plugin' to set some properties they are lost to the JRuby process.
